### PR TITLE
Improve usage of standard library

### DIFF
--- a/from_csr.hpp
+++ b/from_csr.hpp
@@ -38,7 +38,7 @@ void run(std::vector<IndexT> const & A_rows, std::vector<IndexT> const & A_cols,
 {
   B_cols.resize(A_cols.size());
   B_values.resize(A_values.size()); // note: initialization with zero not strictly required
-  B_rows.resize(A_rows.size());     // note: initialization with zero not strictly required
+  B_rows = std::vector<IndexT>(A_rows.size(), 0);
 
   std::size_t N = A_rows.size() - 1;
 


### PR DESCRIPTION
Hi! I'm interested in the sparse matrix transpose problem and started using your code as a testbench.  I have a couple of observations about `from_csr.hpp`:

- `B_rows` is read before it is written and so should be initialized... simply resizing it is not enough
- The first two raw loops have equivalents in the standard library that could be used instead.

I hope you like these changes.  Thanks for making your work public.